### PR TITLE
Add support for Laravel 5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 	}
   ],
   "require": {
-	"illuminate/support": "5.2.x",
+	"illuminate/support": "5.2.x|5.3.x",
 	"tecnickcom/tcpdf": "6.2.12"
   },
   "autoload": {


### PR DESCRIPTION
Add support for `illuminate/support` version 5.3
