### PR TITLE
Add bookmark sorting before TOC creation

### DIFF
--- a/src/TCPDFHelper.php
+++ b/src/TCPDFHelper.php
@@ -44,4 +44,19 @@ class TCPDFHelper extends \TCPDF
         $this->footerCallback = $callback;
     }
 
+    public function addTOC($page = '', $numbersfont = '', $filler = '.', $toc_name = 'TOC', $style = '', $color = array(0, 0, 0))
+    {
+        // sort bookmarks before generating the TOC
+        parent::sortBookmarks();
+
+        parent::addTOC($page, $numbersfont, $filler, $toc_name, $style, $color);
+    }
+
+    public function addHTMLTOC($page = '', $toc_name = 'TOC', $templates = array(), $correct_align = true, $style = '', $color = array(0, 0, 0))
+    {
+        // sort bookmarks before generating the TOC
+        parent::sortBookmarks();
+
+        parent::addHTMLTOC($page, $toc_name, $templates, $correct_align, $style, $color);
+    }
 }


### PR DESCRIPTION
This is a small fix for an issue that happens with the Table of Content when moving pages. 

Sometimes you can only generate a page after some other operations have already happened. And then you need to move some pages around. In this case, the Bookmarks work as they should, the ToC links work properly, but the order of the entries inside the ToC is the one before moving the pages. 

Sorting the bookmarks before generating the content will fix the issue.