### PR TITLE
update tcpdf version 6.3 + laravel 6.1 fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 	}
   ],
   "require": {
-	"illuminate/support": "6.0.*",
+	"illuminate/support": "^6.0",
 	"tecnickcom/tcpdf": "6.3.*"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   ],
   "require": {
 	"illuminate/support": "6.0.*",
-	"tecnickcom/tcpdf": "6.2.*"
+	"tecnickcom/tcpdf": "6.3.*"
   },
   "autoload": {
 	"psr-4": {


### PR DESCRIPTION
closes #82 and also fixes laravel version contraint (laravel 6.1 is released and we cannot update because of this package).