### PR TITLE
Support PHP 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   ],
   "require": {
 	"illuminate/support": "^6.0|^7.0|^8.0",
-	"tecnickcom/tcpdf": "6.2.*|6.3.*"
+	"tecnickcom/tcpdf": "6.2.*|6.3.*|dev-master"
   },
   "autoload": {
 	"psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   ],
   "require": {
 	"illuminate/support": "^6.0|^7.0|^8.0",
-	"tecnickcom/tcpdf": "6.2.*|6.3.*|dev-master"
+	"tecnickcom/tcpdf": "6.2.*|6.3.*|dev-main"
   },
   "autoload": {
 	"psr-4": {


### PR DESCRIPTION
The tcpdf library has some recent pull requests merged which should support PHP 8. However these are currently on master and not in a release yet. This will allow us to install dev-master tcpdf so we can run it on php 8.