### PR TITLE
PHP 8 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 
 {
-  "name": "elibyy/tcpdf-laravel",
+  "name": "marufmax/tcpdf-laravel",
   "description": "tcpdf support for Laravel 6, 7, 8",
   "minimum-stability": "stable",
   "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 
 {
-  "name": "marufmax/tcpdf-laravel",
+  "name": "elibyy/tcpdf-laravel",
   "description": "tcpdf support for Laravel 6, 7, 8",
   "minimum-stability": "stable",
   "license": "MIT",
@@ -17,7 +17,7 @@
   ],
   "require": {
 	"illuminate/support": "^6.0|^7.0|^8.0",
-	"tecnickcom/tcpdf": "6.2.*|6.3.*||dev-main"
+	"tecnickcom/tcpdf": "6.2.*|6.3.*|dev-main"
   },
   "autoload": {
 	"psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   ],
   "require": {
 	"illuminate/support": "^6.0|^7.0|^8.0",
-	"tecnickcom/tcpdf": "6.2.*|6.3.*"
+	"tecnickcom/tcpdf": "6.2.*|6.3.*||dev-main"
   },
   "autoload": {
 	"psr-4": {


### PR DESCRIPTION
The tcpdf library has some recent pull requests merged which should support PHP 8. However these are currently on master and not in a release yet. This will allow us to install dev-master tcpdf so we can run it on php 8.

See tecnickcom/TCPDF#222 

