### PR TITLE
add disableTcpdfLink to fpdi helper

### DIFF
--- a/src/FpdiTCPDFHelper.php
+++ b/src/FpdiTCPDFHelper.php
@@ -45,4 +45,9 @@ class FpdiTCPDFHelper extends TcpdfFpdi
         $this->footerCallback = $callback;
     }
 
+    public function disableTcpdfLink()
+    {
+        // disable tcpdf metalink *sigh*
+        $this->tcpdflink = false;
+    }
 }


### PR DESCRIPTION
This pull request adds `disableTcpdfLink` to `FpdiTCPDFHelper`class and fixes a bug introduced by 290ad7bc5acf424d3f1c6208f3efd13906b6b9f5

`Call to undefined method Elibyy\TCPDF\FpdiTCPDFHelper::disableTcpdfLink()`